### PR TITLE
Proposed solution to avoid require cache providing unpredictable module instances

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -204,7 +204,9 @@ const registerHelpers = config => new Promise((resolve, reject) => {
   walker.on('file', async (root, stats, next) => {
     try {
       const file_path = path.resolve(config.templates, path.resolve(root, stats.name));
-      require(file_path);
+      // If it's a module constructor, inject dependencies to ensure consistent usage in remote templates in other projects or plain directories.
+      const mod = require(file_path);
+      if(typeof mod == "function") mod(_, Handlebars);
       next();
     } catch (e) {
       reject(e);

--- a/templates/express/.helpers/all.js
+++ b/templates/express/.helpers/all.js
@@ -1,125 +1,129 @@
-const _ = require('lodash');
-const Handlebars = require('handlebars');
+// Module constructor provides dependency injection from the generator instead of relying on require's cache here to ensure
+// the same instance of Handlebars gets the helpers installed and Lodash is definitiely available
+// regardless of where remote templates reside: in another Node project or a plain directory, which may have different or no modules available.
+module.exports = (_, Handlebars) =>{
 
-/**
- * Compares two values.
- */
-Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
-  if (arguments.length < 3)
-    throw new Error('Handlebars Helper equal needs 2 parameters');
-  if (lvalue!=rvalue) {
-    return options.inverse(this);
-  }
+  /**
+   * Compares two values.
+   */
+  Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper equal needs 2 parameters');
+    if (lvalue!=rvalue) {
+      return options.inverse(this);
+    }
 
-  return options.fn(this);
-});
-
-/**
- * Checks if a string ends with a provided value.
- */
-Handlebars.registerHelper('endsWith', (lvalue, rvalue, options) => {
-  if (arguments.length < 3)
-    throw new Error('Handlebars Helper equal needs 2 parameters');
-  if (lvalue.lastIndexOf(rvalue) !== lvalue.length-1 || lvalue.length-1 < 0) {
-    return options.inverse(this);
-  }
-  return options.fn(this);
-});
-
-/**
- * Checks if a method is a valid HTTP method.
- */
-Handlebars.registerHelper('validMethod', (method, options) => {
-  const authorized_methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
-
-  if (arguments.length < 3)
-    throw new Error('Handlebars Helper validMethod needs 1 parameter');
-  if (authorized_methods.indexOf(method.toUpperCase()) === -1) {
-    return options.inverse(this);
-  }
-
-  return options.fn(this);
-});
-
-/**
- * Checks if a collection of responses contains no error responses.
- */
-Handlebars.registerHelper('ifNoErrorResponses', (responses, options) => {
-  const codes = responses ? Object.keys(responses) : [];
-  if (codes.find(code => Number(code) >= 400)) return options.inverse(this);
-
-  return options.fn(this);
-});
-
-/**
- * Checks if a collection of responses contains no success responses.
- */
-Handlebars.registerHelper('ifNoSuccessResponses', (responses, options) => {
-  const codes = responses ? Object.keys(responses) : [];
-  if (codes.find(code => Number(code) >= 200 && Number(code) < 300)) return options.inverse(this);
-
-  return options.fn(this);
-});
-
-/**
- * Checks if a string matches a RegExp.
- */
-Handlebars.registerHelper('match', (lvalue, rvalue, options) => {
-  if (arguments.length < 3)
-    throw new Error('Handlebars Helper match needs 2 parameters');
-  if (!lvalue.match(rvalue)) {
-    return options.inverse(this);
-  }
-
-  return options.fn(this);
-});
-
-/**
- * Provides different ways to compare two values (i.e. equal, greater than, different, etc.)
- */
-Handlebars.registerHelper('compare', (lvalue, rvalue, options) => {
-  if (arguments.length < 3) throw new Error('Handlebars Helper "compare" needs 2 parameters');
-
-  const operator = options.hash.operator || '==';
-  const operators = {
-    '==':       (l,r) => { return l == r; },
-    '===':      (l,r) => { return l === r; },
-    '!=':       (l,r) => { return l != r; },
-    '<':        (l,r) => { return l < r; },
-    '>':        (l,r) => { return l > r; },
-    '<=':       (l,r) => { return l <= r; },
-    '>=':       (l,r) => { return l >= r; },
-    typeof:     (l,r) => { return typeof l == r; }
-  };
-
-  if (!operators[operator]) throw new Error(`Handlebars Helper 'compare' doesn't know the operator ${operator}`);
-
-  const result = operators[operator](lvalue,rvalue);
-
-  if (result) {
     return options.fn(this);
-  }
+  });
 
-  return options.inverse(this);
-});
+  /**
+   * Checks if a string ends with a provided value.
+   */
+  Handlebars.registerHelper('endsWith', (lvalue, rvalue, options) => {
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper equal needs 2 parameters');
+    if (lvalue.lastIndexOf(rvalue) !== lvalue.length-1 || lvalue.length-1 < 0) {
+      return options.inverse(this);
+    }
+    return options.fn(this);
+  });
 
-/**
- * Capitalizes a string.
- */
-Handlebars.registerHelper('capitalize', (str) => {
-  return _.capitalize(str);
-});
+  /**
+   * Checks if a method is a valid HTTP method.
+   */
+  Handlebars.registerHelper('validMethod', (method, options) => {
+    const authorized_methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
 
-/**
- * Converts a string to its camel-cased version.
- */
-Handlebars.registerHelper('camelCase', (str) => {
-  return _.camelCase(str);
-});
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper validMethod needs 1 parameter');
+    if (authorized_methods.indexOf(method.toUpperCase()) === -1) {
+      return options.inverse(this);
+    }
 
-/**
- * Converts a multi-line string to a single line.
- */
-Handlebars.registerHelper('inline', (str) => {
-  return str ? str.replace(/\n/g, '') : '';
-});
+    return options.fn(this);
+  });
+
+  /**
+   * Checks if a collection of responses contains no error responses.
+   */
+  Handlebars.registerHelper('ifNoErrorResponses', (responses, options) => {
+    const codes = responses ? Object.keys(responses) : [];
+    if (codes.find(code => Number(code) >= 400)) return options.inverse(this);
+
+    return options.fn(this);
+  });
+
+  /**
+   * Checks if a collection of responses contains no success responses.
+   */
+  Handlebars.registerHelper('ifNoSuccessResponses', (responses, options) => {
+    const codes = responses ? Object.keys(responses) : [];
+    if (codes.find(code => Number(code) >= 200 && Number(code) < 300)) return options.inverse(this);
+
+    return options.fn(this);
+  });
+
+  /**
+   * Checks if a string matches a RegExp.
+   */
+  Handlebars.registerHelper('match', (lvalue, rvalue, options) => {
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper match needs 2 parameters');
+    if (!lvalue.match(rvalue)) {
+      return options.inverse(this);
+    }
+
+    return options.fn(this);
+  });
+
+  /**
+   * Provides different ways to compare two values (i.e. equal, greater than, different, etc.)
+   */
+  Handlebars.registerHelper('compare', (lvalue, rvalue, options) => {
+    if (arguments.length < 3) throw new Error('Handlebars Helper "compare" needs 2 parameters');
+
+    const operator = options.hash.operator || '==';
+    const operators = {
+      '==':       (l,r) => { return l == r; },
+      '===':      (l,r) => { return l === r; },
+      '!=':       (l,r) => { return l != r; },
+      '<':        (l,r) => { return l < r; },
+      '>':        (l,r) => { return l > r; },
+      '<=':       (l,r) => { return l <= r; },
+      '>=':       (l,r) => { return l >= r; },
+      typeof:     (l,r) => { return typeof l == r; }
+    };
+
+    if (!operators[operator]) throw new Error(`Handlebars Helper 'compare' doesn't know the operator ${operator}`);
+
+    const result = operators[operator](lvalue,rvalue);
+
+    if (result) {
+      return options.fn(this);
+    }
+
+    return options.inverse(this);
+  });
+
+  /**
+   * Capitalizes a string.
+   */
+  Handlebars.registerHelper('capitalize', (str) => {
+    return _.capitalize(str);
+  });
+
+  /**
+   * Converts a string to its camel-cased version.
+   */
+  Handlebars.registerHelper('camelCase', (str) => {
+    return _.camelCase(str);
+  });
+
+  /**
+   * Converts a multi-line string to a single line.
+   */
+  Handlebars.registerHelper('inline', (str) => {
+    return str ? str.replace(/\n/g, '') : '';
+  });
+
+}

--- a/templates/markdown/.helpers/accepted-values.js
+++ b/templates/markdown/.helpers/accepted-values.js
@@ -1,7 +1,9 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-Handlebars.registerHelper('acceptedValues', items => {
-  if (!items) return '<em>Any</em>';
+  Handlebars.registerHelper('acceptedValues', items =>{
+    if(!items) return '<em>Any</em>';
 
-  return items.map(i => `<code>${i}</code>`).join(', ');
-});
+    return items.map(i => `<code>${i}</code>`).join(', ');
+  });
+
+}

--- a/templates/markdown/.helpers/build-path.js
+++ b/templates/markdown/.helpers/build-path.js
@@ -1,6 +1,8 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-Handlebars.registerHelper('buildPath', (propName, path, key) => {
-  if (!path) return propName;
-  return `${path}.${propName}`;
-});
+  Handlebars.registerHelper('buildPath', (propName, path, key) => {
+    if (!path) return propName;
+    return `${path}.${propName}`;
+  });
+
+}

--- a/templates/markdown/.helpers/equal.js
+++ b/templates/markdown/.helpers/equal.js
@@ -1,11 +1,13 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
-  if (arguments.length < 3)
-    throw new Error('Handlebars Helper equal needs 2 parameters');
-  if (lvalue!==rvalue) {
-    return options.inverse(this);
-  }
+  Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper equal needs 2 parameters');
+    if (lvalue!==rvalue) {
+      return options.inverse(this);
+    }
+  
+    return options.fn(this);
+  });
 
-  return options.fn(this);
-});
+}

--- a/templates/markdown/.helpers/is-required.js
+++ b/templates/markdown/.helpers/is-required.js
@@ -1,6 +1,8 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-Handlebars.registerHelper('isRequired', (obj, key) => {
-  if (!obj || !obj.required) return false;
-  return !!(obj.required.includes(key));
-});
+  Handlebars.registerHelper('isRequired', (obj, key) => {
+    if (!obj || !obj.required) return false;
+    return !!(obj.required.includes(key));
+  });
+  
+}

--- a/templates/markdown/.helpers/stringify.js
+++ b/templates/markdown/.helpers/stringify.js
@@ -1,9 +1,11 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-Handlebars.registerHelper('stringify', json => {
-  try {
-    return JSON.stringify(json || '', null, 2);
-  } catch (e) {
-    return '';
-  }
-});
+  Handlebars.registerHelper('stringify', json => {
+    try {
+      return JSON.stringify(json || '', null, 2);
+    } catch (e) {
+      return '';
+    }
+  });
+
+}

--- a/templates/markdown/.helpers/tree.js
+++ b/templates/markdown/.helpers/tree.js
@@ -1,10 +1,12 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-Handlebars.registerHelper('tree', path => {
-  if (!path) return '';
-  const filteredPaths = path.split('.').filter(Boolean);
-  if (!filteredPaths.length) return;
-  const dottedPath = filteredPaths.join('.');
-
-  return `${dottedPath}.`;
-});
+  Handlebars.registerHelper('tree', path => {
+    if (!path) return '';
+    const filteredPaths = path.split('.').filter(Boolean);
+    if (!filteredPaths.length) return;
+    const dottedPath = filteredPaths.join('.');
+  
+    return `${dottedPath}.`;
+  });
+  
+}

--- a/templates/markdown/.helpers/uppercase.js
+++ b/templates/markdown/.helpers/uppercase.js
@@ -1,8 +1,10 @@
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-/**
- * Uppercases a string.
- */
-Handlebars.registerHelper('uppercase', (str) => {
-  return str.toUpperCase();
-});
+  /**
+   * Uppercases a string.
+   */
+  Handlebars.registerHelper('uppercase', (str) => {
+    return str.toUpperCase();
+  });
+  
+}

--- a/templates/markdown/.helpers/valid-method.js
+++ b/templates/markdown/.helpers/valid-method.js
@@ -1,17 +1,18 @@
-const _ = require('lodash');
-const Handlebars = require('handlebars');
+module.exports = (_, Handlebars) =>{
 
-/**
- * Checks if a method is a valid HTTP method.
- */
-Handlebars.registerHelper('validMethod', (method, options) => {
-  const authorized_methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
-
-  if (arguments.length < 3)
-    throw new Error('Handlebars Helper validMethod needs 1 parameter');
-  if (authorized_methods.indexOf(method.toUpperCase()) === -1) {
-    return options.inverse(this);
-  }
-
-  return options.fn(this);
-});
+  /**
+   * Checks if a method is a valid HTTP method.
+   */
+  Handlebars.registerHelper('validMethod', (method, options) => {
+    const authorized_methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
+  
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper validMethod needs 1 parameter');
+    if (authorized_methods.indexOf(method.toUpperCase()) === -1) {
+      return options.inverse(this);
+    }
+  
+    return options.fn(this);
+  });
+  
+}


### PR DESCRIPTION
re. Issue https://github.com/fmvilas/openapi3-generator/issues/6

Note most of the diffs to the templates are whitespace as I indented them.
The changes are really just:

    - const _ = require('lodash'); 
    - const Handlebars = require('handlebars');
    + module.exports = (_, Handlebars) =>{
    ...
    + }