### PR TITLE
fix generated example path for response

### DIFF
--- a/templates/markdown/.partials/response.md
+++ b/templates/markdown/.partials/response.md
@@ -61,11 +61,11 @@ _No headers specified_
 {{/equal}}
 {{/equal}}
 {{else}}
-{{#if content.generatedExample}}
+{{#if content.schema.generatedExample}}
 ##### Example _(generated)_
 
 ```json
-{{{stringify content.generatedExample}}}
+{{{stringify content.schema.generatedExample}}}
 ```
 {{/if}}
 {{/if}}


### PR DESCRIPTION
This fix solve the problem where generated example for response message was not used due to wrong json path.