### PR TITLE
Fall back to schema name if we don't have a title

### DIFF
--- a/templates/markdown/openapi.md.hbs
+++ b/templates/markdown/openapi.md.hbs
@@ -25,8 +25,10 @@
 {{#each openapi.components.schemas as |schema schemaName|}}
 {{#if schema.slug}}
   - [{{schema.title}}](#{{schema.slug}})
-{{else}}
+{{else if schema.title}}
   - {{schema.title}}
+{{else}}
+  - {{schemaName}}
 {{/if}}
 {{/each}}
 {{/if}}


### PR DESCRIPTION
When rendering the petstore example the schemas in the toc are blank because of missing title attributes, falling back to the schema name works in this case.

```
* [Servers](#servers)
* [Paths](#paths)
  - [`GET` /pets](#op-get-pets) 
  - [`POST` /pets](#op-post-pets) 
  - [`GET` /pets/{petId}](#op-get-pets-petid) 
* [Schemas](#schemas)
  -
  -
  -
```