### PR TITLE
Handle empty path map

### DIFF
--- a/lib/beautifier.js
+++ b/lib/beautifier.js
@@ -5,6 +5,7 @@ const md = require('markdown-it')();
 const curlGenerator = require('./curl-builder');
 
 const sharedStart = (array) => {
+  if (array.length == 0) { return ''; }
   const A = array.concat().sort();
   const a1 = A[0], a2 = A[A.length - 1], L = a1.length;
   let i = 0;


### PR DESCRIPTION
If the path list is empty like in this example

```
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths: {}
components: {}
```

I see the following error
```
og -t ../schema/templates/ -o ./schemas -b $(pwd) ../schema/petstore.yaml markdown
TypeError: Cannot read property 'length' of undefined
    at sharedStart (/usr/local/lib/node_modules/openapi3-generator/lib/beautifier.js:9:49)
    at module.exports (/usr/local/lib/node_modules/openapi3-generator/lib/beautifier.js:182:24)
    at bundle.catch.then (/usr/local/lib/node_modules/openapi3-generator/lib/generator.js:288:17)
```

This is a special case where the path array has no elements, so can be handled explicitly