### PR TITLE
added asciidoc template

### DIFF
--- a/templates/asciidoctor/.helpers/accepted-values.js
+++ b/templates/asciidoctor/.helpers/accepted-values.js
@@ -1,0 +1,9 @@
+module.exports = (Handlebars, _) =>{
+
+  Handlebars.registerHelper('acceptedValues', items =>{
+    if(!items) return 'Any';
+
+    return items.map(i => `<code>${i}</code>`).join(', ');
+  });
+
+}

--- a/templates/asciidoctor/.helpers/build-path.js
+++ b/templates/asciidoctor/.helpers/build-path.js
@@ -1,0 +1,8 @@
+module.exports = (Handlebars, _) =>{
+
+  Handlebars.registerHelper('buildPath', (propName, path, key) => {
+    if (!path) return propName;
+    return `${path}.${propName}`;
+  });
+
+}

--- a/templates/asciidoctor/.helpers/equal.js
+++ b/templates/asciidoctor/.helpers/equal.js
@@ -1,0 +1,13 @@
+module.exports = (Handlebars, _) =>{
+
+  Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper equal needs 2 parameters');
+    if (lvalue!==rvalue) {
+      return options.inverse(this);
+    }
+
+    return options.fn(this);
+  });
+
+}

--- a/templates/asciidoctor/.helpers/is-required.js
+++ b/templates/asciidoctor/.helpers/is-required.js
@@ -1,0 +1,8 @@
+module.exports = (Handlebars, _) =>{
+
+  Handlebars.registerHelper('isRequired', (obj, key) => {
+    if (!obj || !obj.required) return false;
+    return !!(obj.required.includes(key));
+  });
+
+}

--- a/templates/asciidoctor/.helpers/stringify.js
+++ b/templates/asciidoctor/.helpers/stringify.js
@@ -1,0 +1,14 @@
+module.exports = (Handlebars, _) =>{
+
+  Handlebars.registerHelper('stringify', json => {
+    if (!(json instanceof String) && typeof json !== 'string' ) {
+      try {
+        return JSON.stringify(json || '', null, 2);
+      } catch (e) {
+        return '';
+      }
+    } else {
+      return json;
+    }	    
+  });
+}

--- a/templates/asciidoctor/.helpers/tree.js
+++ b/templates/asciidoctor/.helpers/tree.js
@@ -1,0 +1,12 @@
+module.exports = (Handlebars, _) =>{
+
+  Handlebars.registerHelper('tree', path => {
+    if (!path) return '';
+    const filteredPaths = path.split('.').filter(Boolean);
+    if (!filteredPaths.length) return;
+    const dottedPath = filteredPaths.join('.');
+
+    return `${dottedPath}.`;
+  });
+
+}

--- a/templates/asciidoctor/.helpers/uppercase.js
+++ b/templates/asciidoctor/.helpers/uppercase.js
@@ -1,0 +1,10 @@
+module.exports = (Handlebars, _) =>{
+
+  /**
+   * Uppercases a string.
+   */
+  Handlebars.registerHelper('uppercase', (str) => {
+    return str.toUpperCase();
+  });
+
+}

--- a/templates/asciidoctor/.helpers/valid-method.js
+++ b/templates/asciidoctor/.helpers/valid-method.js
@@ -1,0 +1,18 @@
+module.exports = (Handlebars, _) =>{
+
+  /**
+   * Checks if a method is a valid HTTP method.
+   */
+  Handlebars.registerHelper('validMethod', (method, options) => {
+    const authorized_methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
+
+    if (arguments.length < 3)
+      throw new Error('Handlebars Helper validMethod needs 1 parameter');
+    if (authorized_methods.indexOf(method.toUpperCase()) === -1) {
+      return options.inverse(this);
+    }
+
+    return options.fn(this);
+  });
+
+}

--- a/templates/asciidoctor/.partials/cookieParams.adoc.hbs
+++ b/templates/asciidoctor/.partials/cookieParams.adoc.hbs
@@ -1,0 +1,16 @@
+[discrete]
+==== Cookie parameters
+
+{{#each cookieParams as |cookieParam|}}
+{{#if cookieParam.name}}
+[discrete]
+===== {icon-triangle} {{cookieParam.name}}
+{{/if}}
+
+{{#if cookieParam.description}}
+{{{cookieParam.description}}}
+{{/if}}
+
+{{> parameter param=cookieParam paramName=cookieParam.name hideTitle=true}}
+
+{{/each}}

--- a/templates/asciidoctor/.partials/curl.adoc.hbs
+++ b/templates/asciidoctor/.partials/curl.adoc.hbs
@@ -1,0 +1,7 @@
+[discrete]
+===== cURL Script ({i18n-a-generated})
+
+[source]
+----
+{{{curl}}}
+----

--- a/templates/asciidoctor/.partials/example.adoc.hbs
+++ b/templates/asciidoctor/.partials/example.adoc.hbs
@@ -1,0 +1,31 @@
+{{#if example}}
+[discrete]
+===== {i18n-h-example}
+
+{{#if summary}}> {{{summary}}}{{/if}}
+
+{{#if description}}{{{description}}}{{/if}}
+
+[source, json]
+----
+{{{stringify example}}}
+----
+{{else}}
+{{#if generatedExample}}
+[discrete]
+===== {i18n-h-example} _({i18n-a-generated})_
+
+[source, json]
+----
+{{{stringify generatedExample}}}
+----
+{{/if}}
+{{/if}}
+
+{{#if externalValue}}
+{{#unless example}}
+[discrete]
+===== {i18n-h-example}
+{{/unless}}
+[Download example]({{externalValue}})
+{{/if}}

--- a/templates/asciidoctor/.partials/headers.adoc.hbs
+++ b/templates/asciidoctor/.partials/headers.adoc.hbs
@@ -1,0 +1,16 @@
+[discrete]
+==== {i18n-h-headers}
+
+{{#each headers as |header|}}
+{{#if header.name}}
+[discrete]
+===== {icon-triangle} {{header.name}}
+{{/if}}
+
+{{#if header.description}}
+{{{header.description}}}
+{{/if}}
+
+{{> parameter param=header paramName=header.name hideTitle=true}}
+
+{{/each}}

--- a/templates/asciidoctor/.partials/info.adoc.hbs
+++ b/templates/asciidoctor/.partials/info.adoc.hbs
@@ -1,0 +1,5 @@
+{{#if openapi.info.termsOfService}}
+[[termsOfService]]
+== Terms of service
+{{openapi.info.termsOfService}}
+{{/if}}

--- a/templates/asciidoctor/.partials/operation.adoc.hbs
+++ b/templates/asciidoctor/.partials/operation.adoc.hbs
@@ -1,0 +1,75 @@
+{{#if operation.summary}}
+----
+{{{operation.summary}}}
+----
+{{/if}}
+{{#if operation.description}}
+{{{operation.description}}}
+{{/if}}
+{{#if operation.curl}}
+{{> curl curl=operation.curl}}
+{{/if}}
+{{#if operation.pathParams}}
+{{> pathParams pathParams=operation.pathParams}}
+{{/if}}
+{{#if operation.headers}}
+{{> headers headers=operation.headers}}
+{{/if}}
+{{#if operation.queryParams}}
+{{> queryParams queryParams=operation.queryParams}}
+{{/if}}
+{{#if operation.cookieParams}}
+{{> cookieParams cookieParams=operation.cookieParams}}
+{{/if}}
+{{#if operation.requestBody}}
+[discrete]
+==== {i18n-h-request-body}
+{{#each operation.requestBody.content as |contentType contentTypeName| }}
+[discrete]
+===== {{contentTypeName}}
+{{> schema schema=schema schemaName='body' hideTitle=true hideExamples=true}}
+{{#if examples}}
+{{#each examples as |example exampleName|}}
+{{> example example=example.value description=example.description externalValue=example.externalValue}}
+{{/each}}
+{{else}}
+{{#if example}}
+{{> example example=example.value description=example.description externalValue=example.externalValue}}
+{{else}}
+{{> example example=schema.example generatedExample=schema.generatedExample }}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{#each operation.parameters}}
+{{#equal in 'body'}}
+[discrete]
+==== {i18n-h-request-body}
+{{> schema schema=../schema schemaName='body' hideTitle=true hideExamples=true}}
+{{#if ../examples}}
+{{#each ../examples as |example exampleName|}}
+{{> example example=example.value description=example.description}}
+{{/each}}
+{{else}}
+{{#if example}}
+{{> example example=example.value description=example.description }}
+{{else}}
+{{> example example=schema.example generatedExample=schema.generatedExample }}
+{{/if}}
+{{/if}}
+{{/equal}}
+{{/each}}
+{{#if operation.responses}}
+
+[discrete]
+==== {i18n-h-responses}
+
+{{> responses responses=operation.responses hideTitle=true}}
+{{/if}}
+{{#if operation.tags}}
+
+[discrete]
+==== Tags
+
+{{> tags tags=operation.tags}}
+{{/if}}

--- a/templates/asciidoctor/.partials/param-prop.adoc.hbs
+++ b/templates/asciidoctor/.partials/param-prop.adoc.hbs
@@ -1,0 +1,29 @@
+|{{tree path}}{{propName}} {{#if prop.required}} _({i18n-a-required})_{{/if}}
+|
+{{#if prop.schema}}
+{{prop.schema.type}}
+{{~#if prop.schema.anyOf}}anyOf{{~/if}}
+{{~#if prop.schema.oneOf}}oneOf{{~/if}}
+{{~#if prop.schema.items.type}}({{prop.schema.items.type}}){{~/if}}
+{{else}}
+unknown
+{{/if}}
+|{{prop.in}}
+|+++{{{prop.descriptionAsHTML}}} +++
+|{{{acceptedValues prop.schema.enum}}}
+
+{{#each prop.anyOf}}
+{{> paramProp prop=. propName=@key path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.oneOf}}
+{{> paramProp prop=. propName=@key path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.properties}}
+{{> paramProp prop=. propName=@key required=(isRequired ../prop @key) path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.additionalProperties.properties}}
+{{> paramProp prop=. propName=@key required=(isRequired ../prop.additionalProperties @key) path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.items.properties}}
+{{> paramProp prop=. propName=@key required=(isRequired ../prop.items @key) path=(buildPath ../propName ../path @key)}}
+{{/each}}

--- a/templates/asciidoctor/.partials/parameter.adoc.hbs
+++ b/templates/asciidoctor/.partials/parameter.adoc.hbs
@@ -1,0 +1,26 @@
+{{#unless hideTitle}}
+[discrete]
+==== {{parameterName}}
+{{/unless}}
+
+[cols="^1,^1,^1,^1,^1", options="header"]
+|====
+|{i18n-th-name} |{i18n-th-type} |{i18n-th-in} |{i18n-th-description} |{i18n-th-accepted-values}
+{{#each param.schema.properties}}
+{{> paramProp prop=. propName=@key required=(isRequired ../schema @key) path=''}}
+{{else}}
+{{> paramProp prop=param propName=paramName required=(isRequired ../schema @key) path=''}}
+{{/each}}
+|====
+
+{{#unless hideExamples}}
+{{#if schema.example}}
+[discrete]
+===== Example
+
+[source, json]
+----
+{{{stringify param.schema.example}}}
+----
+{{/if}}
+{{/unless}}

--- a/templates/asciidoctor/.partials/parameters.adoc.hbs
+++ b/templates/asciidoctor/.partials/parameters.adoc.hbs
@@ -1,0 +1,18 @@
+[discrete]
+==== {i18n-h-headers}
+
+{{#each params as |param|}}
+{{#equal param.in 'header'}}
+{{#if param.name}}
+[discrete]
+===== {{param.name}}
+{{/if}}
+
+{{#if param.description}}
+{{{param.description}}}
+{{/if}}
+
+{{> parameter param=param paramName=param.name hideTitle=true}}
+
+{{/equal}}
+{{/each}}

--- a/templates/asciidoctor/.partials/path.adoc.hbs
+++ b/templates/asciidoctor/.partials/path.adoc.hbs
@@ -1,0 +1,14 @@
+{{#each path}}
+{{#validMethod @key}}
+[[{{../slug}}]]
+{{#if ../deprecated}}
+=== _(DEPRECATED)_ *{{uppercase @key}}* {{../../pathName}}
+{{else}}
+=== *{{uppercase @key}}* {{../../pathName}}
+{{/if}}
+//tag::{{../slug}}[]
+{{> operation operation=.. operationName=(uppercase @key)}}
+
+//end::{{../slug}}[]
+{{/validMethod}}
+{{/each}}

--- a/templates/asciidoctor/.partials/pathParams.adoc.hbs
+++ b/templates/asciidoctor/.partials/pathParams.adoc.hbs
@@ -1,0 +1,16 @@
+[discrete]
+==== Path parameters
+
+{{#each pathParams as |pathParam|}}
+{{#if pathParam.name}}
+[discrete]
+===== {icon-triangle} {{pathParam.name}}
+{{/if}}
+
+{{#if pathParam.description}}
+{{{pathParam.description}}}
+{{/if}}
+
+{{> parameter param=pathParam paramName=pathParam.name hideTitle=true}}
+
+{{/each}}

--- a/templates/asciidoctor/.partials/paths.adoc.hbs
+++ b/templates/asciidoctor/.partials/paths.adoc.hbs
@@ -1,0 +1,6 @@
+[[paths]]
+== {i18n-h-paths} 
+
+{{#each openapi.paths}}
+{{>path path=. pathName=@key}}
+{{/each}}

--- a/templates/asciidoctor/.partials/queryParams.adoc.hbs
+++ b/templates/asciidoctor/.partials/queryParams.adoc.hbs
@@ -1,0 +1,16 @@
+[discrete]
+==== Query parameters
+
+{{#each queryParams as |queryParam|}}
+{{#if queryParam.name}}
+[discrete]
+===== {icon-triangle} {{queryParam.name}}
+{{/if}}
+
+{{#if queryParam.description}}
+{{{queryParam.description}}}
+{{/if}}
+
+{{> parameter param=queryParam paramName=queryParam.name hideTitle=true}}
+
+{{/each}}

--- a/templates/asciidoctor/.partials/response.adoc.hbs
+++ b/templates/asciidoctor/.partials/response.adoc.hbs
@@ -1,0 +1,90 @@
+{{#unless hideTitle}}
+[discrete]
+==== {{responseName}}
+{{/unless}}
+[discrete]
+====== {i18n-h-headers}
+{{#each response.headers as |header headerName|}}
+===== {{headerName}}
+{{> schema schema=header.schema schemaName=headerName hideTitle=true hideExamples=true}}
+
+{{#if header.schema.example}}
+{{#equal contentType 'application/json'}}
+[source, json]
+----
+{{{stringify header.schema.example}}}
+----
+{{else}}
+{{#equal contentType 'application/xml'}}
+[source,xml]
+----
+{{{header.schema.example}}}
+----
+{{else}}
+[source]
+----
+{{{header.schema.example}}}
+----
+{{/equal}}
+{{/equal}}
+{{else}}
+{{#if header.generatedExample}}
+[source, json]
+----
+{{{stringify header.generatedExample}}}
+----
+{{/if}}
+{{/if}}
+
+{{else}}
+_{i18n-p-no-headers-specified}_
+{{/each}}
+
+{{#if response.content}}
+{{#each response.content as |content contentType|}}
+[discrete]
+====== {{contentType}}
+{{#if content.description}}
+{{{content.description}}}
+{{/if}}
+{{> schema schema=content.schema schemaName='Response' hideTitle=true hideExamples=true}}
+
+{{#if content.examples}}
+{{#each content.examples as |example exampleName|}}
+{{> example example=example.value description=example.description externalValue=example.externalValue}}
+{{/each}}
+{{/if}}
+{{#if content.schema.example}}
+[discrete]
+===== {i18n-h-example}
+{{#equal contentType 'application/json'}}
+[source, json]
+----
+{{{stringify content.schema.example}}}
+----
+{{else}}
+{{#equal contentType 'application/xml'}}
+[source, xml]
+----
+{{{content.schema.example}}}
+----
+{{else}}
+[source]
+----
+{{{content.schema.example}}}
+----
+{{/equal}}
+{{/equal}}
+{{else}}
+{{#if content.schema.generatedExample}}
+[discrete]
+===== {i18n-h-example} _({i18n-a-generated})_
+
+[source, json]
+----
+{{{stringify content.schema.generatedExample}}}
+----
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}

--- a/templates/asciidoctor/.partials/responses.adoc.hbs
+++ b/templates/asciidoctor/.partials/responses.adoc.hbs
@@ -1,0 +1,13 @@
+{{#unless hideTitle}}
+[discrete]
+==== {i18n-h-responses} 
+{{/unless}}
+
+{{#each responses as |response responseCode|}}
+{{#if responseCode}}
+[discrete]
+===== {icon-triangle} {{responseCode}} {{#if response.description}}- {{{response.description}}}{{/if}}
+{{/if}}
+
+{{~> response response=response responseName=responseCode hideTitle=true ~}}
+{{/each}}

--- a/templates/asciidoctor/.partials/schema-prop.adoc.hbs
+++ b/templates/asciidoctor/.partials/schema-prop.adoc.hbs
@@ -1,0 +1,24 @@
+|{{#if prop.deprecated}}<s>{{tree path}}{{propName}}</s> (deprecated){{else}}{{tree path}}{{propName}}{{/if}}{{#if required}} _({i18n-a-required})_{{/if}}
+|
+    {{prop.type}}
+    {{~#if prop.anyOf}}anyOf{{~/if}}
+    {{~#if prop.oneOf}}oneOf{{~/if}}
+    {{~#if prop.items.type}}({{prop.items.type}}){{~/if}}
+|+++{{{prop.descriptionAsHTML}}}+++
+|+++{{{acceptedValues prop.enum}}}+++ 
+
+{{#each prop.anyOf}}
+{{> schemaProp prop=. propName=@key path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.oneOf}}
+{{> schemaProp prop=. propName=@key path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.properties}}
+{{> schemaProp prop=. propName=@key required=(isRequired ../prop @key) path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.additionalProperties.properties}}
+{{> schemaProp prop=. propName=@key required=(isRequired ../prop.additionalProperties @key) path=(buildPath ../propName ../path @key)}}
+{{/each}}
+{{#each prop.items.properties}}
+{{> schemaProp prop=. propName=@key required=(isRequired ../prop.items @key) path=(buildPath ../propName ../path @key)}}
+{{/each}}

--- a/templates/asciidoctor/.partials/schema.adoc.hbs
+++ b/templates/asciidoctor/.partials/schema.adoc.hbs
@@ -1,0 +1,43 @@
+{{#if schema.slug}}[[{{schema.slug}}]]{{/if}}
+{{#unless hideTitle}}
+{{#if schema.title}}
+=== {{schema.title}}
+{{else}}
+=== {{schemaName}}
+{{/if}}
+{{/unless}}
+{{#if schema.slug}}//tag::{{schema.slug}}[]{{/if}}
+[cols="1,^1,1,^1", options="header"]
+|====
+^|{i18n-th-name} ^|{i18n-th-type} ^|{i18n-th-description} ^|{i18n-th-accepted-values}
+{{#each schema.properties}}
+{{> schemaProp prop=. propName=@key required=(isRequired ../schema @key) path=''}}
+{{else}}
+{{> schemaProp prop=schema propName=schemaName required=(isRequired ../schema @key) path=''}}
+{{/each}}
+|====
+
+{{#unless hideExamples}}
+{{#if schema.example}}
+[discrete]
+==== {i18n-h-example}
+
+[source, json]
+----
+{{{stringify schema.example}}}
+----
+
+{{else}}
+{{#if schema.generatedExample}}
+[discrete]
+==== {i18n-h-example} _({i18n-a-generated})_
+
+[source, json]
+----
+{{{stringify schema.generatedExample}}}
+----
+
+{{/if}}
+{{/if}}
+{{/unless}}
+{{#if schema.slug}}//end::{{schema.slug}}[]{{/if}}

--- a/templates/asciidoctor/.partials/schemas.adoc.hbs
+++ b/templates/asciidoctor/.partials/schemas.adoc.hbs
@@ -1,0 +1,10 @@
+{{#unless openapi.__noSchemas}}
+[[schemas]]
+//tag::schemas[]
+== {i18n-h-schemas} 
+
+{{#each openapi.components.schemas}}
+  {{~>schema schema=. schemaName=@key renderSlug=true~}}
+{{/each}}
+//end::schemas[]
+{{/unless}}

--- a/templates/asciidoctor/.partials/security.adoc.hbs
+++ b/templates/asciidoctor/.partials/security.adoc.hbs
@@ -1,0 +1,12 @@
+{{#if openapi.components.securitySchemes}}
+[[security]]
+== Security
+
+[cols="1, 1, 1, 1, 1, 1", options="header"]
+|====
+|Type |In |Name |Schema |Format |Description
+{{#each openapi.components.securitySchemes as |security|}}
+|{{security.type}} |{{security.in}} |{{security.name}} |{{security.scheme}} |{{security.bearerFormat}} |+++{{{security.descriptionAsHTML}}}+++
+{{/each}}
+|====
+{{/if}}

--- a/templates/asciidoctor/.partials/servers.adoc.hbs
+++ b/templates/asciidoctor/.partials/servers.adoc.hbs
@@ -1,0 +1,12 @@
+{{#if openapi.servers}}
+[[servers]]
+== {i18n-h-servers} 
+
+[cols="1,1", options="header"]
+|====
+|URL |{i18n-th-description}
+{{#each openapi.servers as |server|}}
+|{{server.url}} |{{server.description}}
+{{/each}}
+|====
+{{/if}}

--- a/templates/asciidoctor/.partials/tags.adoc.hbs
+++ b/templates/asciidoctor/.partials/tags.adoc.hbs
@@ -1,0 +1,6 @@
+
+{{#each tags}}
+  * {{./name}}
+{{else}}
+  No tags
+{{/each}}

--- a/templates/asciidoctor/openapi.adoc.hbs
+++ b/templates/asciidoctor/openapi.adoc.hbs
@@ -1,0 +1,56 @@
+= {{openapi.info.title}}
+// ------------------------------------------------------------
+// To translate this document just make another asciidoc file 
+// with required i18n attribute values and include this one
+//
+// include::openapi.adoc[]
+//
+// or make another file with necessary title and i18n attribute
+// values and include only tag "body"
+// 
+// include::openapi.adoc[tag=body]
+// 
+// This approach lets you define your own attributes,
+// for example ":toc: left" to generate table of contents.
+//  
+// Each paths and schemas section is anchored and marked 
+// with corresponding tag to make possible separate use in your 
+// document. Schemas are tagged and anchored only if they've 
+// got a title.
+// ------------------------------------------------------------
+ifndef::api-lang[]
+:api-lang: en-en
+:i18n-h-servers: Servers
+:i18n-h-paths: Paths
+:i18n-h-security: Security
+:i18n-h-schemas: Schemas 
+:i18n-th-description: Description 
+:i18n-th-in: In
+:i18n-th-name: Name
+:i18n-th-type: Type
+:i18n-th-accepted-values: Accepted values
+:i18n-h-responses: Responses
+:i18n-h-headers: Headers
+:i18n-p-no-headers-specified: No header specified
+:i18n-h-request-body: Request body
+:i18n-h-example: Example
+:i18n-a-generated: Generated
+:i18n-a-required: Required
+:i18n-h-api-description: API description 
+:icon-triangle: &#9655;
+endif::[]
+
+//tag::body[]
+
++++{{{openapi.info.descriptionAsHTML}}} +++
+
+{{> info}}
+
+{{> servers}}
+
+{{> security}}
+
+{{> paths }}
+
+{{> schemas }}
+//end::body[]


### PR DESCRIPTION
- added support to examples directly in contents as in api-with-examples.yaml
- changed stringify function to enable both ways of specifiyng example: as a string (second example in api-with-examples.yaml) as part of the specification (other examples in api-with-examples.yaml)
- added i18n support via asciidoc attributes